### PR TITLE
[UADS-005] Added firebase config to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ yarn-error.log*
 
 # ide files
 .idea
+
+# config
+config/


### PR DESCRIPTION
Issue: Need to ignore firebase credentials.
Solution: Added credentials to config folder and included folder in
gitignore.
Risk: None.
Reviewed by: Daniel.